### PR TITLE
fix: warning generated by sls offline about promise, callback

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -127,20 +127,20 @@ export class GraphQLServerLambda {
         debug: this.options.debug,
       }
     })
-    return handler(event, context, callbackFilter)
+    handler(event, context, callbackFilter)
   }
 
   playgroundHandler = (event, lambdaContext, callback) => {
-    return lambdaPlayground({
+    lambdaPlayground({
       endpoint: this.options.endpoint,
     })(event, lambdaContext, callback)
   }
 
   handler = (event, lambdaContext, callback) => {
     if (event.httpMethod === 'GET') {
-      return this.playgroundHandler(event, lambdaContext, callback)
+      this.playgroundHandler(event, lambdaContext, callback)
     } else {
-      return this.graphqlHandler(event, lambdaContext, callback)
+      this.graphqlHandler(event, lambdaContext, callback)
     }
   }
 }


### PR DESCRIPTION
`sls offline` plugin throws a warning when a lambda handler function returns a promise and calls the callback. This PR fixes that.

<img width="942" alt="screen shot 2018-06-13 at 2 55 26 pm" src="https://user-images.githubusercontent.com/746482/41352644-522ba9ec-6f1a-11e8-9ae3-611ed29a5e65.png">
