### PR TITLE
fixed type cast issue; added handler for uncaught errors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,4 @@
+import { AddressInfo } from 'net'
 import test, { TestContext, Context } from 'ava'
 import { inflate } from 'graphql-deduplicator'
 import { GraphQLServer, Options } from './index'
@@ -50,7 +51,7 @@ async function startServer(t: TestContext & Context<any>, options?: Options) {
 
   const server = new GraphQLServer({ typeDefs, resolvers })
   const http = await server.start({ port: 0, ...options })
-  const { port } = http.address()
+  const { port } = http.address() as AddressInfo
   const uri = `http://localhost:${port}/`
 
   if (t.context.httpServers) {


### PR DESCRIPTION
When sending illegal JSON query request, unexpected exceptions may raise, which will print stack traces to expose server's file structure. the way to recreate the issue is 

```shell
curl -vv  http://localhost:18022/graphql -H 'Content-Type: application/json' --data '{"": "query { __schema { types {name } }}"}'
```
and the response is 
```html
< HTTP/1.1 500 Internal Server Error

<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Error: Must provide document<br> &nbsp; &nbsp;at invariant (./node_modules/graphql/jsutils/invariant.js:19:11)<br> &nbsp; &nbsp;at Object.validate (./node_modules/graphql/validation/validate.js:56:34)<br> &nbsp; &nbsp;at doRunQuery (./node_modules/apollo-server-core/dist/runQuery.js:110:38)<br> &nbsp; &nbsp;at ./node_modules/apollo-server-core/dist/runQuery.js:21:56<br> &nbsp; &nbsp;at process._tickCallback (internal/process/next_tick.js:68:7)</pre>
</body>
</html>
```

so I write an error handler to disable stack printing when error occurs.