### PR TITLE
fix: potential incorrect merge conflict resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,20 +3,12 @@
   "version": "0.0.0-semantic-release",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/graphcool/graphql-yoga.git"
   },
-  "keywords": [
-    "graphql",
-    "server",
-    "api",
-    "graphql-server",
-    "apollo"
-  ],
+  "keywords": ["graphql", "server", "api", "graphql-server", "apollo"],
   "author": "Johannes Schickling <johannes@graph.cool>",
   "license": "MIT",
   "bugs": {
@@ -26,7 +18,8 @@
   "scripts": {
     "prepublish": "yarn build",
     "build": "rm -rf dist && tsc -d",
-    "lint": "tslint --project tsconfig.json {src,test}/**/*.ts && prettier-check --ignore-path .gitignore {src,.}/{*.ts,*.js}",
+    "lint":
+      "tslint --project tsconfig.json {src,test}/**/*.ts && prettier-check --ignore-path .gitignore {src,.}/{*.ts,*.js}",
     "format": "prettier --write --ignore-path .gitignore {src,.}/{*.ts,*.js}",
     "test": "yarn lint && yarn build && ava",
     "watch:tsc": "tsc --watch",
@@ -37,9 +30,7 @@
     "branch": "master"
   },
   "ava": {
-    "files": [
-      "dist/**/*.test.js"
-    ]
+    "files": ["dist/**/*.test.js"]
   },
   "dependencies": {
     "@types/cors": "^2.8.4",
@@ -57,7 +48,7 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0",
     "graphql-deduplicator": "^2.0.1",
     "graphql-import": "^0.6.0",
-    "graphql-middleware": "1.3.3",
+    "graphql-middleware": "1.5.0",
     "graphql-playground-middleware-express": "1.6.3",
     "graphql-playground-middleware-lambda": "1.6.1",
     "graphql-subscriptions": "^0.5.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,11 @@ import {
 import { importSchema } from 'graphql-import'
 import { deflate } from 'graphql-deduplicator'
 import expressPlayground from 'graphql-playground-middleware-express'
-import { makeExecutableSchema, addMockFunctionsToSchema, defaultMergedResolver } from 'graphql-tools'
+import {
+  makeExecutableSchema,
+  addMockFunctionsToSchema,
+  defaultMergedResolver,
+} from 'graphql-tools'
 import { applyMiddleware as applyFieldMiddleware } from 'graphql-middleware'
 import { createServer, Server as HttpServer } from 'http'
 import { createServer as createHttpsServer, Server as HttpsServer } from 'https'
@@ -261,7 +265,7 @@ export class GraphQLServer {
           formatError: this.options.formatError || defaultErrorFormatter,
           logFunction: this.options.logFunction,
           rootValue: this.options.rootValue,
-          validationRules: this.options.validationRules,
+          validationRules:
             typeof this.options.validationRules === 'function'
               ? this.options.validationRules(request, response)
               : this.options.validationRules,
@@ -300,7 +304,7 @@ export class GraphQLServer {
             logFunction: this.options.logFunction,
             rootValue: this.options.rootValue,
             validationRules: this.options.validationRules as ValidationRules,
-            fieldResolver: this.options.fieldResolver || customFieldResolver,
+            fieldResolver: this.options.fieldResolver || defaultMergedResolver,
             formatParams: this.options.formatParams,
             formatResponse: this.options.formatResponse,
             debug: this.options.debug,

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,9 +108,9 @@ export interface SubscriptionServerOptions {
 }
 
 export interface Props<
-  TMiddlewareSource = any,
-  TMiddlewareContext = any,
-  TMiddlewareArgs = any
+  TFieldMiddlewareSource = any,
+  TFieldMiddlewareContext = any,
+  TFieldMiddlewareArgs = any
 > {
   directiveResolvers?: IDirectiveResolvers<any, any>
   schemaDirectives?: {
@@ -123,9 +123,9 @@ export interface Props<
   context?: Context | ContextCallback
   mocks?: IMocks
   middlewares?: IFieldMiddleware<
-    TMiddlewareSource,
-    TMiddlewareContext,
-    TMiddlewareArgs
+    TFieldMiddlewareSource,
+    TFieldMiddlewareContext,
+    TFieldMiddlewareArgs
   >[]
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1837,9 +1837,9 @@ graphql-import@^0.6.0:
   dependencies:
     lodash "^4.17.4"
 
-graphql-middleware@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-1.3.3.tgz#c6898df07c8d58a2f49c6ba3b0a49ec946f3d300"
+graphql-middleware@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-middleware/-/graphql-middleware-1.5.0.tgz#b539cbc34df8ea7b077415102e87fd704188d7ec"
   dependencies:
     graphql-tools "^3.0.2"
 
@@ -1873,7 +1873,7 @@ graphql-subscriptions@^0.5.8:
   dependencies:
     iterall "^1.2.1"
 
-graphql-tools@^2.23.1, graphql-tools@^2.24.0:
+graphql-tools@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.24.0.tgz#bbacaad03924012a0edb8735a5e65df5d5563675"
   dependencies:


### PR DESCRIPTION
`yarn test` still yields the following error in middleware types. 

```
src/types.ts(125,17): error TS2315: Type 'IMiddleware' is not generic.
```