### PR TITLE
Support `resolverValidationOptions` in lambda

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -27,7 +27,13 @@ export class GraphQLServerLambda {
     if (props.schema) {
       this.executableSchema = props.schema
     } else if (props.typeDefs && props.resolvers) {
-      let { directiveResolvers, schemaDirectives, typeDefs, resolvers } = props
+      let {
+        directiveResolvers,
+        schemaDirectives,
+        resolverValidationOptions,
+        typeDefs,
+        resolvers,
+      } = props
 
       // read from .graphql file if path provided
       if (typeDefs.endsWith('graphql')) {
@@ -45,6 +51,7 @@ export class GraphQLServerLambda {
       this.executableSchema = makeExecutableSchema({
         directiveResolvers,
         schemaDirectives,
+        resolverValidationOptions,
         typeDefs,
         resolvers,
       })

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface LambdaProps {
   }
   typeDefs?: string
   resolvers?: IResolvers
+  resolverValidationOptions?: IResolverValidationOptions
   schema?: GraphQLSchema
   context?: Context | ContextCallback
   options?: LambdaOptions


### PR DESCRIPTION
Fixes #313 (https://github.com/prismagraphql/prisma/issues/2225)  for `GraphQLServerLambda`, this was fixed for `GraphQLServer` in pull request #270