### PR TITLE
Add middlewares to GraphQLServerLambda

### DIFF
--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -4,6 +4,7 @@ import { GraphQLSchema } from 'graphql'
 import { importSchema } from 'graphql-import'
 import lambdaPlayground from 'graphql-playground-middleware-lambda'
 import { makeExecutableSchema, defaultMergedResolver } from 'graphql-tools'
+import { applyMiddleware as applyFieldMiddleware } from 'graphql-middleware'
 import { deflate } from 'graphql-deduplicator'
 import * as path from 'path'
 
@@ -55,6 +56,13 @@ export class GraphQLServerLambda {
         typeDefs,
         resolvers,
       })
+    }
+
+    if (props.middlewares) {
+      this.executableSchema = applyFieldMiddleware(
+        this.executableSchema,
+        ...props.middlewares,
+      )
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,11 @@ export interface Props<
   >[]
 }
 
-export interface LambdaProps {
+export interface LambdaProps<
+  TFieldMiddlewareSource = any,
+  TFieldMiddlewareContext = any,
+  TFieldMiddlewareArgs = any
+> {
   directiveResolvers?: IDirectiveResolvers<any, any>
   schemaDirectives?: {
     [name: string]: typeof SchemaDirectiveVisitor
@@ -140,6 +144,11 @@ export interface LambdaProps {
   schema?: GraphQLSchema
   context?: Context | ContextCallback
   options?: LambdaOptions
+  middlewares?: IFieldMiddleware<
+    TFieldMiddlewareSource,
+    TFieldMiddlewareContext,
+    TFieldMiddlewareArgs
+  >[]
 }
 
 export interface LambdaOptions extends ApolloServerOptions {


### PR DESCRIPTION
Closes #398 wrapping `executableSchema` with `applyMiddleware` from [graphql-middleware](https://github.com/prismagraphql/graphql-middleware)