### PR TITLE
Update graphql-playground-middleware-express

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "graphql-deduplicator": "^2.0.1",
     "graphql-import": "^0.6.0",
     "graphql-middleware": "1.5.0",
-    "graphql-playground-middleware-express": "1.6.3",
+    "graphql-playground-middleware-express": "1.7.2",
     "graphql-playground-middleware-lambda": "1.6.1",
     "graphql-subscriptions": "^0.5.8",
     "graphql-tools": "^2.24.0",


### PR DESCRIPTION
This updates the `graphql-playground-middleware-express` dependency. I tested this out locally on my end and this fixed an issue where settting `"request.credentials": "include"` in the playground settings was working to pass the browser cookies along to the `/graphql` endpoint. It wasn't working before with `1.6.3`.